### PR TITLE
fix(var): Rename "absolute" references to "progress"

### DIFF
--- a/src/engine.py
+++ b/src/engine.py
@@ -45,9 +45,9 @@ class GameEngine:
             b = self.state.board
             pl = b.players
             # in game terms players are 0..n, in state terms they are (not necessarily ordered unique identifiers)
-            game_piece = GamePiece(pl.index(piece.player), piece.number, piece.position)
+            game_piece = GamePiece(pl.index(piece.player), piece.number, piece.progress)
             status = [
-                GamePiece(pl.index(p.player), p.number, p.position) for p in b.pieces
+                GamePiece(pl.index(p.player), p.number, p.progress) for p in b.pieces
             ]
             if is_valid_move(
                 game_piece,
@@ -58,7 +58,7 @@ class GameEngine:
                 b.end_progress,
             ):
                 creator = (
-                    GameMove.piece_out if piece.position == 0 else GameMove.move_piece
+                    GameMove.piece_out if piece.progress == 0 else GameMove.move_piece
                 )
                 valid_actions.append(creator(player, piece.number, dice))
 
@@ -75,13 +75,13 @@ class GameEngine:
     def __knock_out_other_players(self, piece: Piece) -> None:
         for p in self.state.board.pieces:
             if p.player != piece.player:
-                p.position = 0
+                p.progress = 0
                 return  # only one piece can be knocked out
 
     def __on_piece_out(self, piece: Piece, dice: int) -> GameState:
         assert self.state.board.is_on_start(piece)
         assert dice == 6
-        piece.position = 1
+        piece.progress = 1
         self.__knock_out_other_players(piece)
         self.state.valid_actions = [GameMove.roll_dice(piece.player)]
         self.state.number = self.state.number + 1
@@ -92,12 +92,12 @@ class GameEngine:
             winner = True
             for _piece in self.state.board.pieces:
                 if _piece.player == piece.player:
-                    winner = winner and _piece.position == self.state.board.end_progress
+                    winner = winner and _piece.progress == self.state.board.end_progress
             return winner
 
         b = self.state.board
-        if piece.position + dice < b.end_progress + 1:
-            piece.position = piece.position + dice
+        if piece.progress + dice < b.end_progress + 1:
+            piece.progress = piece.progress + dice
             if b.is_on_path(piece):
                 self.__knock_out_other_players(piece)
 

--- a/src/engine_test.py
+++ b/src/engine_test.py
@@ -106,8 +106,8 @@ def test_play_until_the_end_two_players_once_piece(monkeypatch):
     assert new_state.number == 2
     assert new_state.dice == 6
     assert new_state.board.pieces == [
-        Piece(number=0, player=0, position=1),
-        Piece(number=0, player=2, position=0),
+        Piece(number=0, player=0, progress=1),
+        Piece(number=0, player=2, progress=0),
     ]
     assert new_state.valid_actions == [GameMove.roll_dice(player=0)]
 
@@ -124,8 +124,8 @@ def test_play_until_the_end_two_players_once_piece(monkeypatch):
     assert new_state.number == 4
     assert new_state.winners == []
     assert new_state.board.pieces == [
-        Piece(number=0, player=0, position=7),
-        Piece(number=0, player=2, position=0),
+        Piece(number=0, player=0, progress=7),
+        Piece(number=0, player=2, progress=0),
     ]
     assert new_state.valid_actions == [GameMove.roll_dice(player=0)]
 
@@ -141,14 +141,14 @@ def test_play_until_the_end_two_players_once_piece(monkeypatch):
     # Then the piece should go forward and we should be able to roll the dice again
     assert new_state.number == 6
     assert new_state.board.pieces == [
-        Piece(number=0, player=0, position=13),
-        Piece(number=0, player=2, position=0),
+        Piece(number=0, player=0, progress=13),
+        Piece(number=0, player=2, progress=0),
     ]
     assert new_state.winners == []
     assert new_state.valid_actions == [GameMove.roll_dice(player=0)]
 
     # And When we position the piece toward the end of the board
-    new_state.board.pieces[0].position = board.end_progress - 6
+    new_state.board.pieces[0].progress = board.end_progress - 6
 
     # And When we roll the dice again with 6
     new_state = game.play(GameMove.roll_dice(player=0))
@@ -162,8 +162,8 @@ def test_play_until_the_end_two_players_once_piece(monkeypatch):
     # Then the piece should go forward and we should be able to roll the dice again
     assert new_state.number == 8
     assert new_state.board.pieces == [
-        Piece(number=0, player=0, position=board.end_progress),
-        Piece(number=0, player=2, position=0),
+        Piece(number=0, player=0, progress=board.end_progress),
+        Piece(number=0, player=2, progress=0),
     ]
     assert new_state.winners == [0]
     assert new_state.valid_actions == []
@@ -177,7 +177,7 @@ def test_do_not_move_piece_to_end_on_bigger_dice(monkeypatch):
     monkeypatch.setattr(dice, "roll", lambda: 5)
     game = GameEngine(board, dice)
 
-    state.board.pieces[0].position = board.end_progress - 3
+    state.board.pieces[0].progress = board.end_progress - 3
 
     # When we roll the dice with 5 which is bigger then we need to
     # get to the goal
@@ -192,8 +192,8 @@ def test_do_not_move_piece_to_end_on_bigger_dice(monkeypatch):
         GameMove.roll_dice(player=2),
     ]
     assert new_state.board.pieces == [
-        Piece(number=0, player=0, position=board.end_progress - 3),
-        Piece(number=0, player=2, position=0),
+        Piece(number=0, player=0, progress=board.end_progress - 3),
+        Piece(number=0, player=2, progress=0),
     ]
     assert new_state.winners == []
 

--- a/src/game.py
+++ b/src/game.py
@@ -138,7 +138,7 @@ def __coord_on_path(piece: Piece) -> Tuple[int, int]:
     Logic split this in 4 different cases, determined by player offset.
     Parameter piece does't influence logic.
 
-    Player (absolute) Progress to (relative) Position conversion:
+    Player Progress to Position conversion:
         P0     1..56: (pos)
         P1     1..42: (p_num * shift + pos)
               43..56: (p_num * shift + pos) % end_progress

--- a/src/state.py
+++ b/src/state.py
@@ -7,7 +7,7 @@ from enum import Enum
 class Piece:
     number: int
     player: int
-    position: int = 0  # the absolute position on the board, AKA progress
+    progress: int = 0  # the absolute position of a player throughout the game
 
 
 ROLL_DICE = 1
@@ -104,20 +104,22 @@ class Board:
         Has values 1..path_zone_length
         """
         assert self.is_on_path(piece)
-        pos = (self.players.index(piece.player) * self.player_shift) + piece.position
-        return (pos - 1) % self.path_zone_length + 1
+        position = (
+            self.players.index(piece.player) * self.player_shift
+        ) + piece.progress
+        return (position - 1) % self.path_zone_length + 1
 
     def is_on_start(self, piece: Piece) -> bool:
-        return piece.position == 0
+        return piece.progress == 0
 
     def is_on_path(self, piece: Piece) -> bool:
-        return 1 <= piece.position <= self.path_zone_length
+        return 1 <= piece.progress <= self.path_zone_length
 
     def is_on_finish(self, piece: Piece) -> bool:
-        return self.path_zone_length < piece.position < self.end_progress
+        return self.path_zone_length < piece.progress < self.end_progress
 
     def is_on_target(self, piece: Piece) -> bool:
-        return self.end_progress <= piece.position <= self.end_progress + 3
+        return self.end_progress <= piece.progress <= self.end_progress + 3
 
 
 @dataclass

--- a/src/state_test.py
+++ b/src/state_test.py
@@ -221,73 +221,73 @@ def test_board_relative_position():
     board = Board.create()
 
     # Test relative position for each player
-    rel_pos_p0 = board.relative_position(piece=Piece(number=0, player=0, position=20))
+    rel_pos_p0 = board.relative_position(piece=Piece(number=0, player=0, progress=20))
     assert rel_pos_p0 == 20
 
-    rel_pos_p1 = board.relative_position(piece=Piece(number=0, player=1, position=20))
+    rel_pos_p1 = board.relative_position(piece=Piece(number=0, player=1, progress=20))
     assert rel_pos_p1 == 34
 
-    rel_pos_p2 = board.relative_position(piece=Piece(number=0, player=2, position=20))
+    rel_pos_p2 = board.relative_position(piece=Piece(number=0, player=2, progress=20))
     assert rel_pos_p2 == 48
 
-    rel_pos_p3 = board.relative_position(piece=Piece(number=0, player=3, position=20))
+    rel_pos_p3 = board.relative_position(piece=Piece(number=0, player=3, progress=20))
     assert rel_pos_p3 == 6
 
     # Test a position outside of path_zone
     with pytest.raises(Exception):
-        board.relative_position(piece=Piece(number=0, player=0, position=61))
+        board.relative_position(piece=Piece(number=0, player=0, progress=61))
 
 
 def test_board_is_on_start():
     board = Board.create()
 
-    p0_on_start = board.is_on_start(piece=Piece(number=0, player=0, position=0))
+    p0_on_start = board.is_on_start(piece=Piece(number=0, player=0, progress=0))
     assert p0_on_start
 
-    p0_on_start = board.is_on_start(piece=Piece(number=0, player=0, position=1))
+    p0_on_start = board.is_on_start(piece=Piece(number=0, player=0, progress=1))
     assert not p0_on_start
 
-    p0_on_start = board.is_on_start(piece=Piece(number=0, player=0, position=2))
+    p0_on_start = board.is_on_start(piece=Piece(number=0, player=0, progress=2))
     assert not p0_on_start
 
 
 def test_board_is_on_path():
     board = Board.create()
 
-    p0_on_path = board.is_on_path(piece=Piece(number=0, player=0, position=0))
+    p0_on_path = board.is_on_path(piece=Piece(number=0, player=0, progress=0))
     assert not p0_on_path
 
-    p0_on_path = board.is_on_path(piece=Piece(number=0, player=0, position=1))
+    p0_on_path = board.is_on_path(piece=Piece(number=0, player=0, progress=1))
     assert p0_on_path
 
-    p0_on_path = board.is_on_path(piece=Piece(number=0, player=0, position=10))
+    p0_on_path = board.is_on_path(piece=Piece(number=0, player=0, progress=10))
     assert p0_on_path
 
-    p0_on_path = board.is_on_path(piece=Piece(number=0, player=0, position=61))
+    p0_on_path = board.is_on_path(piece=Piece(number=0, player=0, progress=61))
     assert not p0_on_path
 
 
 def test_board_is_on_finish():
     board = Board.create()
 
-    p0_on_finish = board.is_on_finish(piece=Piece(number=0, player=0, position=56))
+    p0_on_finish = board.is_on_finish(piece=Piece(number=0, player=0, progress=56))
     assert not p0_on_finish
 
-    p0_on_finish = board.is_on_finish(piece=Piece(number=0, player=0, position=61))
+    p0_on_finish = board.is_on_finish(piece=Piece(number=0, player=0, progress=61))
     assert p0_on_finish
 
-    p0_on_finish = board.is_on_finish(piece=Piece(number=0, player=0, position=62))
+    p0_on_finish = board.is_on_finish(piece=Piece(number=0, player=0, progress=62))
     assert not p0_on_finish
 
 
 def test_board_is_on_target():
     board = Board.create()
 
-    p0_on_target = board.is_on_target(piece=Piece(number=0, player=0, position=61))
+    p0_on_target = board.is_on_target(piece=Piece(number=0, player=0, progress=61))
     assert not p0_on_target
 
-    p0_on_target = board.is_on_target(piece=Piece(number=0, player=0, position=62))
+    p0_on_target = board.is_on_target(piece=Piece(number=0, player=0, progress=62))
     assert p0_on_target
 
-    p0_on_target = board.is_on_target(piece=Piece(number=0, player=0, position=66))
+    p0_on_target = board.is_on_target(piece=Piece(number=0, player=0, progress=66))
     assert not p0_on_target

--- a/src/util.py
+++ b/src/util.py
@@ -56,5 +56,5 @@ def progress_to_position(
     """
     if position < 1 or position > last_on_path:
         return 0
-    abs_pos = player * player_shift + position
-    return (abs_pos - 1) % last_on_path + 1
+    progress = player * player_shift + position
+    return (progress - 1) % last_on_path + 1


### PR DESCRIPTION
We've decided to use the term `progress` to denote the _absolute_ position of a player throughout the game and `relative position` when referring to their position on the board.

In general, we are only interested in the `relative position` in cases where we need to check for player collision or draw a piece on the board.
